### PR TITLE
Keeping paper-dialog opened property in sync on toggle

### DIFF
--- a/paper-dialog.html
+++ b/paper-dialog.html
@@ -150,7 +150,7 @@ Transition examples:
        * @method toggle
        */
       toggle: function() {
-        this.$.overlay.toggle();
+        this.opened = !this.opened;
       },
 
       headingChanged: function() {


### PR DESCRIPTION
If the overlay is toggled directly then the dialog's opened property gets out of sync since it's used in conditional attribute syntax. Actually was moving things over to conditional syntax intended on the core-overlay element here since it appears it creates a one way binding no?
