### PR TITLE
make core-dialog.open not conditional so it gets propagated back to the ...

### DIFF
--- a/paper-dialog.html
+++ b/paper-dialog.html
@@ -60,7 +60,7 @@ Fired when the dialog's `opened` property changes.
       <paper-shadow z="3" hasPosition></paper-shadow>
     </div>
 
-    <core-overlay id="overlay" opened?="{{opened}}" autoCloseDisabled?="{{autoCloseDisabled}}" backdrop?="{{backdrop}}" layered?="{{layered}}" target="{{}}" sizingTarget="{{$.container}}" closeSelector="{{closeSelector}}" transition="{{transition}}" margin="20"></core-overlay>
+    <core-overlay id="overlay" opened="{{opened}}" autoCloseDisabled?="{{autoCloseDisabled}}" backdrop?="{{backdrop}}" layered?="{{layered}}" target="{{}}" sizingTarget="{{$.container}}" closeSelector="{{closeSelector}}" transition="{{transition}}" margin="20"></core-overlay>
 
     <div id="container" layout vertical>
 
@@ -92,7 +92,7 @@ Fired when the dialog's `opened` property changes.
        * @default false
        */
       opened: false,
-    
+
       /**
        * If true, the dialog has a backdrop darkening the rest of the screen.
        * The backdrop element is attached to the document body and may be styled
@@ -102,7 +102,7 @@ Fired when the dialog's `opened` property changes.
        * @attribute backdrop
        * @type boolean
        * @default false
-       */    
+       */
       backdrop: false,
 
       /**
@@ -151,7 +151,7 @@ Fired when the dialog's `opened` property changes.
        */
       transition: '',
 
-      /** 
+      /**
        * Toggle the dialog's opened state.
        * @method toggle
        */


### PR DESCRIPTION
...consumer
