### PR TITLE
Remove border override for paper-dialog content

### DIFF
--- a/paper-dialog.css
+++ b/paper-dialog.css
@@ -39,5 +39,4 @@ h1 {
 polymer-next-selector { content: ':host > *'; }
 ::content > * {
   font: inherit;
-  border: 0;
 }


### PR DESCRIPTION
See http://www.dartosphere.org/2014/08/25/at-the-bottom-of-the-rabbit-hole-i-find-polyfill-next-selector.html#.U_yWPXWx3UY. I tested it out briefly and don't see a reason for this border: 0; style either. If there is something specific that is trying to be targeted it should probably be put in a less general selector?
