### PR TITLE
Add import to transition module

### DIFF
--- a/paper-dialog.html
+++ b/paper-dialog.html
@@ -29,17 +29,13 @@ Example:
 
 #### Transitions
 
-`<paper-dialog>` can be used with `<paper-transition>` to transition the overlay open and close.
+`<paper-dialog>` has option to transition the overlay open/close. Currently two transitions are available: `paper-dialog-transition-center` and `paper-dialog-transition-bottom`.
 
-To use a transition, import `paper-dialog-transition.html` alongside paper-dialog:
+To use a transition, set the `transition` attribute for the component:
 
-    <link rel="import" href="paper-dialog/paper-dialog-transition.html">
+    <paper-dialog transition="paper-dialog-transition-center" heading="Title for dialog">
 
-Then set the `transition` attribute:
-
-    <paper-dialog heading="Title for dialog" transition="paper-dialog-transition-center">
-
-    <paper-dialog heading="Title for dialog" transition="paper-dialog-transition-bottom">
+    <paper-dialog transition="paper-dialog-transition-bottom" heading="Title for dialog">
 
 @group Paper Elements
 @element paper-dialog
@@ -55,6 +51,8 @@ Fired when the dialog's `opened` property changes.
 <link href="../polymer/polymer.html" rel="import">
 <link href="../core-overlay/core-overlay.html" rel="import">
 <link href="../paper-shadow/paper-shadow.html" rel="import">
+
+<link href="paper-dialog-transition.html" rel="import">
 
 <polymer-element name="paper-dialog" attributes="opened heading transition autoCloseDisabled backdrop layered closeSelector" role="dialog">
 


### PR DESCRIPTION
This commit fixes issue #32. This was triggered because paper-dialog had
hard dependency to the paper-dialog-transition component, even though
documentation said it was optional. We fix this by importing transition
component from paper-dialog and updating documentation to reflect the
change.

Documentation now also highlights transition attribute in examples to
make them more visible in component description page, as currently the
values of transition attributes are clipped.
