### PR TITLE
Update paper-dialog and paper-action-dialog to support light dom headings

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -73,6 +73,36 @@
       height: 300px;
     }
 
+    /* Info dialog is blue
+     -------------------------------------------------- */
+    html /deep/ .info::shadow #headingContainer {
+      background-color: #66C0E9;
+    }
+
+    html /deep/ .info::shadow #contentContainer {
+      background-color: #fefefe;
+      color: #66C0E9;
+    }
+
+    /* RW dialog is green
+     -------------------------------------------------- */
+    html /deep/ .green::shadow #headingContainer {
+      background-color: #4fb500;
+    }
+
+    html /deep/ .green::shadow #contentContainer {
+      background-color: #fefefe;
+      color: #4fb500;
+    }
+
+    /* Rounded... or whatever.
+     -------------------------------------------------- */
+    html /deep/ .rounded::shadow #scroller {
+      border-radius: 15px;
+      overflow: hidden;
+    }
+
+
   </style>
 
 <!--
@@ -124,15 +154,20 @@
       Dialog with heading
     </button>
 
-    <paper-dialog heading="Title">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <paper-dialog
+      class="info">
+      <h1 class="heading">Title</h1>
+      <h2 class="heading">Subtitle</h2>
+      <p class="content">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </paper-dialog>
 
     <button>
       Dialog with actions
     </button>
 
-    <paper-action-dialog heading="Title">
+    <paper-action-dialog
+      class-"green rounded">
+      <h1 class="heading">Title</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
       <paper-button dismissive>More Info...</paper-button>
@@ -160,7 +195,12 @@
       Dialog with heading
     </button>
 
-    <paper-dialog heading="Title" class="scrolling">
+    <paper-dialog class="scrolling">
+      <div class="heading">
+        <h1>Title</h1>
+        <h2>Subtitle</h2>
+        <p>Tagline or something</p>
+      </div>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -177,8 +217,8 @@
       Dialog with actions
     </button>
 
-    <paper-action-dialog heading="Title" class="scrolling">
-
+    <paper-action-dialog class="scrolling">
+      <h1 class="heading">Title</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -224,7 +264,8 @@
       Colors
     </button>
 
-    <paper-dialog heading="Custom Colors" class="colored">
+    <paper-dialog class="colored">
+      <h1 class="heading">Custom Colors</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </paper-dialog>
 
@@ -232,7 +273,8 @@
       Size &amp; Position
     </button>
 
-    <paper-dialog heading="Custom Size &amp; Position" class="size-position">
+    <paper-dialog class="size-position">
+      <h1 class="heading">Custom Size &amp; Position</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </paper-dialog>
 

--- a/paper-action-dialog.html
+++ b/paper-action-dialog.html
@@ -37,30 +37,34 @@ Example:
 
 <link href="paper-dialog-base.html" rel="import">
 
-<polymer-element name="paper-action-dialog" extends="paper-dialog-base" role="dialog" layout vertical>
+<polymer-element name="paper-action-dialog" extends="paper-dialog-base" role="dialog">
 
 <template>
 
   <style>
     :host {
-      background: #fff;
+      background: none;
       color: rgba(0, 0, 0, 0.87);
       margin: 32px;
       overflow: visible !important;
     }
 
-    h1 {
-      font-size: 20px;
-    }
-
     #scroller {
       overflow: auto;
       box-sizing: border-box;
-      padding: 24px 24px 0 24px;
+    }
+    #headingContainer {
+      padding: 24px;
+      background-color: #fff;
+    }
+    #contentContainer {
+      padding: 24px;
+      background-color: #fff;
     }
 
     #actions {
       padding: 16px;
+      background-color: #fff;
     }
   </style>
 
@@ -68,11 +72,12 @@ Example:
 
   <!-- need this because the host needs to be overflow: visible -->
   <div id="scroller" relative flex auto>
-    <template if="{{heading}}">
-      <h1>{{heading}}</h1>
-    </template>
-
-    <content select=":not([affirmative]):not([dismissive])"></content>
+    <div id="headingContainer">
+      <content id="heading" select=".heading"></content>
+    </div>
+    <div id="contentContainer">
+      <content id="content" select=":not([affirmative]):not([dismissive])"></content>
+    </div>
   </div>
 
   <div id="actions" relative layout horizontal>

--- a/paper-dialog.html
+++ b/paper-dialog.html
@@ -62,26 +62,29 @@ By default, the `aria-label` will be set to the value of the `heading` attribute
 
 <link href="paper-dialog-base.html" rel="import">
 
-<polymer-element name="paper-dialog" extends="paper-dialog-base" role="dialog" layout vertical noscript>
+<polymer-element name="paper-dialog" extends="paper-dialog-base" role="dialog" layout vertical>
 
 <template>
 
   <style>
     :host {
-      background: #fff;
+      background: none;
       color: rgba(0, 0, 0, 0.87);
       margin: 32px;
       overflow: visible !important;
     }
 
-    h1 {
-      font-size: 20px;
-    }
-
     #scroller {
       overflow: auto;
       box-sizing: border-box;
+    }
+    #headingContainer {
       padding: 24px;
+      background-color: #fff;
+    }
+    #contentContainer {
+      padding: 24px;
+      background-color: #fff;
     }
   </style>
 
@@ -89,13 +92,26 @@ By default, the `aria-label` will be set to the value of the `heading` attribute
 
   <!-- need this because the host needs to be overflow: visible -->
   <div id="scroller" relative flex auto>
-    <template if="{{heading}}">
-      <h1>{{heading}}</h1>
-    </template>
-
-    <content></content>
+    <div id="headingContainer">
+      <content id="heading" select=".heading"></content>
+    </div>
+    <div id="contentContainer">
+      <content id="content" select=".content"></content>
+      <content></content>
+    </div>
   </div>
 
 </template>
-
+<script>
+  Polymer({
+    domReady: function() {
+      this.hideEmptyHeader();
+    },
+    hideEmptyHeader: function() {
+      if(this.querySelectorAll('.heading').length < 1) {
+        this.$.headingContainer.setAttribute('hidden', 'hidden');
+      }
+    }
+  });
+</script>
 </polymer-element>

--- a/paper-dialog.html
+++ b/paper-dialog.html
@@ -106,6 +106,7 @@ By default, the `aria-label` will be set to the value of the `heading` attribute
   Polymer({
     domReady: function() {
       this.hideEmptyHeader();
+      this.onMutation(this, this.hideEmptyHeader);
     },
     hideEmptyHeader: function() {
       if(this.querySelectorAll('.heading').length < 1) {


### PR DESCRIPTION
References issue #46  
Update paper-dialog and paper-action-dialog to support light dom headings
- class="heading" will move objects from light dom into heading
- allows multiple dom node headings (heading & subheading, etc)
  - allows for nested dom in a heading, such as a span in an h1, improving css style potential
- adjustments make some styling simpler (such as rounded corners on the dialog)
